### PR TITLE
Remove stale requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
 
     install_requires=[
         'beets>=1.3.13',
-        'futures',
     ],
 
     classifiers=[


### PR DESCRIPTION
The `concurrent` library is part of Python 3 stdlib, by requiring futures we fetch the old py2 version which causes syntax errors on py3.